### PR TITLE
Minor features

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,112 @@
+name: Build
+on:
+    pull_request:
+        branches:
+            - main
+    workflow_dispatch: {}
+env:
+    CGO_ENABLED: "0"
+    GOFLAGS: -trimpath
+jobs:
+    lint-go:
+        container:
+            image: golangci/golangci-lint:v2.11.3-alpine
+            options: --entrypoint ""
+        continue-on-error: true
+        if: ${{ github.event.pull_request.number }}
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v5
+            - name: Cache dependencies
+              uses: actions/cache@v4
+              with:
+                key: go-mod
+                path: /go/pkg/mod
+            - name: Run
+              run: golangci-lint run --timeout 5m ./...
+    vulncheck:
+        container:
+            image: golang:1.26
+        continue-on-error: true
+        if: ${{ github.event.pull_request.number }}
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v5
+            - name: Cache dependencies
+              uses: actions/cache@v4
+              with:
+                key: go-mod
+                path: /go/pkg/mod
+            - name: Run
+              run: |-
+                go install golang.org/x/vuln/cmd/govulncheck@latest
+                govulncheck ./...
+    unit-tests:
+        container:
+            image: golang:1.26
+        needs:
+            - lint-go
+            - vulncheck
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v5
+            - name: Cache dependencies
+              uses: actions/cache@v4
+              with:
+                key: go-mod
+                path: /go/pkg/mod
+            - name: Run
+              run: go test -v -cover -coverprofile=coverage.out -covermode=atomic ./...
+            - if: always()
+              name: Upload artifacts
+              uses: actions/upload-artifact@v4
+              with:
+                name: unit-tests-artifacts
+                path: coverage.out
+    gen-version:
+        container:
+            image: golang:1.26
+        needs:
+            - unit-tests
+        outputs:
+            version: ${{ steps.outputs.outputs.version }}
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v5
+              with:
+                fetch-depth: "0"
+            - name: Mark workspace as safe directory
+              run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
+            - name: Cache dependencies
+              uses: actions/cache@v4
+              with:
+                key: go-mod
+                path: /go/pkg/mod
+            - name: Run
+              run: echo "VERSION=$(git describe --tags --always)" > version.env
+            - id: outputs
+              name: Set outputs
+              run: cat version.env >> $GITHUB_OUTPUT
+    build-binary:
+        container:
+            image: golang:1.26
+        needs:
+            - gen-version
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v5
+            - name: Cache dependencies
+              uses: actions/cache@v4
+              with:
+                key: go-mod
+                path: /go/pkg/mod
+            - name: Run
+              run: 'echo "Version is: "${{ needs.gen-version.outputs.version }}'
+            - name: Run
+              run: go build -buildvcs=false -ldflags "-s -w -X main.pisynVersion=${{ needs.gen-version.outputs.version }}" -o bin/pisyn ./cmd/pisyn
+            - if: always()
+              name: Upload artifacts
+              uses: actions/upload-artifact@v4
+              with:
+                name: build-binary-artifacts
+                path: bin/

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,19 @@
+name: Release Please
+on:
+    push:
+        branches:
+            - main
+    workflow_dispatch: {}
+jobs:
+    release-please:
+        container:
+            image: node:22-alpine
+        env:
+            RELEASE_PAT: ${{ secrets.RELEASE_PAT }}
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v5
+            - name: Run
+              run: |-
+                npx release-please release-pr --repo-url=${{ github.server_url }}/${{ github.repository }} --token=$RELEASE_PAT --release-type=go --pull-request-header=":robot: new release" --pull-request-footer=" "
+                npx release-please github-release --repo-url=${{ github.server_url }}/${{ github.repository }} --token=$RELEASE_PAT --release-type=go

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,21 @@
+name: Release
+on:
+    push:
+        tags:
+            - v*
+    workflow_dispatch: {}
+jobs:
+    goreleaser:
+        container:
+            image: goreleaser/goreleaser:v2.15.2
+        env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v5
+              with:
+                fetch-depth: "0"
+            - name: Mark workspace as safe directory
+              run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
+            - name: Run
+              run: goreleaser release --clean

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,48 @@
+version: 2
+
+project_name: pisyn
+
+before:
+  hooks:
+    - go mod tidy
+    - go test ./...
+
+builds:
+  - main: ./cmd/pisyn
+    binary: pisyn
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w -X main.pisynVersion={{.Version}}
+
+archives:
+  - formats: tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        formats: zip
+
+checksum:
+  name_template: "checksums.txt"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"
+
+release:
+  github:
+    owner: pipecrew
+    name: pisyn
+  draft: false
+  prerelease: auto

--- a/README.md
+++ b/README.md
@@ -613,3 +613,29 @@ Each example has its own README with a detailed explanation, the Mermaid pipelin
 ```sh
 go test ./...
 ```
+
+## Releasing
+
+Releases are automated via [release-please](https://github.com/googleapis/release-please) and [GoReleaser](https://goreleaser.com/).
+
+**Flow:**
+1. Push conventional commits to `main` (`feat:`, `fix:`, `chore:`, etc.)
+2. release-please maintains an open "Release PR" with accumulated changelog and version bump
+3. Merge the Release PR → release-please creates a git tag (`v0.1.0`)
+4. The tag triggers GoReleaser → cross-compiles binaries, creates a GitHub Release with changelog and checksums
+
+**Manual release** (if needed):
+
+```sh
+git tag v0.1.0
+git push origin v0.1.0
+```
+
+### Installing a release
+
+```sh
+# Via go install (requires Go)
+go install github.com/pipecrew/pisyn/cmd/pisyn@v0.1.0
+
+# Or download a binary from the GitHub Releases page
+```

--- a/README.md
+++ b/README.md
@@ -426,6 +426,7 @@ pisyn.NewJob(stage, "deploy").
 pisyn.NewPipeline(app, "CI/CD").
     SetEnv("GO_VERSION", "1.26").
     OnPush("main", "develop").
+    OnPushTag("v*").
     OnPushProtected().
     OnPR("main").
     OnSchedule("0 2 * * *")
@@ -448,7 +449,7 @@ pisyn.NewPipeline(app, "CI").
     })
 ```
 
-If no explicit workflow rules are set, they are auto-generated from `OnPush`/`OnPR`/`OnSchedule` triggers.
+If no explicit workflow rules are set, they are auto-generated from `OnPush`/`OnPushTag`/`OnPR`/`OnSchedule` triggers.
 
 ### Includes (GitLab CI)
 
@@ -582,7 +583,7 @@ golang.TestJob.Clone(stage, "unit-tests").Script("go test ./...")
 | Interruptible | ✅ | ✅ | ❌ | ❌ | ❌ |
 | Extends / inheritance | ❌ | ❌ | ❌ | ❌ | ❌ |
 | Steps (`uses:` actions) | ✅ | ❌ | ✅ | ❌ | ❌ |
-| Triggers (push, PR, schedule) | ✅ | ✅ | ✅ | ❌ | ❌ |
+| Triggers (push, tags, PR, schedule) | ✅ | ✅ | ✅ | ❌ | ❌ |
 | Reusable templates (Clone) | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Pipeline-level env | ✅ | ✅ | ✅ | ❌ | ✅ |
 | Local execution (TUI) | ✅ | ❌ | ❌ | ❌ | ✅ |

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -11,18 +11,25 @@ import (
 func main() {
 	app := ps.NewApp()
 
-	pipeline := ps.NewPipeline(app, "pisyn buildpipeline").
-		OnPush("main").
+	buildPipeline(app)
+	releasePleasePipeline(app)
+	releasePipeline(app)
+
+	if err := app.Run(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func buildPipeline(app *ps.App) {
+	pipeline := ps.NewPipeline(app, "Build").
 		OnPR("main").
 		OnPushProtected().
 		SetEnv("CGO_ENABLED", "0").
 		SetEnv("GOFLAGS", "-trimpath")
 
-	// --- Reusable templates ---
 	goBase := ps.JobTemplate("go-base").
 		Image("golang:1.26").
 		SetCache(ps.Cache{Key: "go-mod", Paths: []string{"/go/pkg/mod"}}).
-		AddTag("non-prod-workload").
 		SetInterruptible(true).
 		SetRetry(ps.RetryConfig{
 			Max:  2,
@@ -38,13 +45,7 @@ func main() {
 		AddRule(ps.Rule{If: ps.VarMRID, When: "always"}).
 		AddRule(ps.Rule{When: "never"}).
 		AllowFailure().
-		Script("golangci-lint run --timeout 5m ./...").
-		SetArtifacts(ps.Artifacts{
-			Paths: []string{"gl-code-quality.json"},
-			Reports: map[string][]string{
-				"codequality": {"gl-code-quality.json"},
-			},
-		})
+		Script("golangci-lint run --timeout 5m ./...")
 
 	goBase.Clone(lint, "vulncheck").
 		AddRule(ps.Rule{If: ps.VarMRID, When: "always"}).
@@ -60,7 +61,7 @@ func main() {
 
 	goBase.Clone(test, "unit-tests").
 		Needs("lint-go", "vulncheck").
-		Script("go test -race -coverprofile=coverage.out -covermode=atomic ./...").
+		Script("go test -v -cover -coverprofile=coverage.out -covermode=atomic ./...").
 		SetArtifacts(ps.Artifacts{
 			Paths:    []string{"coverage.out"},
 			ExpireIn: "7 days",
@@ -69,12 +70,12 @@ func main() {
 			},
 		})
 
-	// --- Build stage (uses version output from gen-version) ---
+	// --- Build stage ---
 	build := ps.NewStage(pipeline, "build")
 
 	genVersion := goBase.Clone(build, "gen-version").
 		Needs("unit-tests").
-		Script("git config --global --add safe.directory "+ps.VarProjectDir).
+		SetFetchDepth(0).
 		Script(`echo "VERSION=$(git describe --tags --always)" > version.env`).
 		Output("VERSION", "version.env")
 
@@ -82,31 +83,38 @@ func main() {
 		Needs("gen-version").
 		Script(`echo "Version is: "` + genVersion.OutputRef("VERSION")).
 		Script(
-			"go build -buildvcs=false  -ldflags \"-s -w -X main.version=" + genVersion.OutputRef("VERSION") + "\" -o bin/pisyn ./cmd/pisyn",
+			"go build -buildvcs=false -ldflags \"-s -w -X main.pisynVersion=" + genVersion.OutputRef("VERSION") + "\" -o bin/pisyn ./cmd/pisyn",
 		).
 		SetArtifacts(ps.Artifacts{
 			Paths:    []string{"bin/"},
 			ExpireIn: "30 days",
 		})
+}
 
-	// --- Release stage (only on main branch, uses version from gen-version) ---
-	release := ps.NewStage(pipeline, "release")
+func releasePleasePipeline(app *ps.App) {
+	pipeline := ps.NewPipeline(app, "Release Please").
+		OnPush("main")
 
-	goBase.Clone(release, "release").
-		Needs("build-binary").
-		AddTag("prod-workload").
-		SetInterruptible(false).
-		If(ps.VarCommitBranch+` == "main"`).
-		AddStep(ps.Step{
-			Uses: "actions/upload-artifact@v4",
-			With: map[string]string{"name": "release-binary", "path": "bin/"},
-		}).
+	stage := ps.NewStage(pipeline, "release-please")
+
+	ps.NewJob(stage, "release-please").
+		Image("node:22-alpine").
+		Env("RELEASE_PAT", "${{ secrets.RELEASE_PAT }}").
 		Script(
-			"echo releasing "+ps.VarProjectPath+" version "+genVersion.OutputRef("VERSION"),
-		).
-		SetEnvironment("production", "https://app.example.com")
+			"npx release-please release-pr --repo-url="+ps.VarProjectURL+" --token=$RELEASE_PAT --release-type=go --pull-request-header=\":robot: new release\" --pull-request-footer=\" \"",
+			"npx release-please github-release --repo-url="+ps.VarProjectURL+" --token=$RELEASE_PAT --release-type=go",
+		)
+}
 
-	if err := app.Run(); err != nil {
-		log.Fatal(err)
-	}
+func releasePipeline(app *ps.App) {
+	pipeline := ps.NewPipeline(app, "Release").
+		OnPushTag("v*")
+
+	stage := ps.NewStage(pipeline, "goreleaser")
+
+	ps.NewJob(stage, "goreleaser").
+		Image("goreleaser/goreleaser:v2.15.2").
+		SetFetchDepth(0).
+		Script("goreleaser release --clean").
+		Env("GITHUB_TOKEN", "${{ secrets.GITHUB_TOKEN }}")
 }

--- a/pkg/pisyn/app_test.go
+++ b/pkg/pisyn/app_test.go
@@ -232,6 +232,20 @@ func TestOnPushPreservesProtected(t *testing.T) {
 	}
 }
 
+func TestOnPushTagPreservesBranches(t *testing.T) {
+	app := NewApp()
+	p := NewPipeline(app, "CI").
+		OnPush("main").
+		OnPushTag("v*")
+
+	if len(p.On.Push.Branches) != 1 || p.On.Push.Branches[0] != "main" {
+		t.Fatalf("OnPushTag should preserve branches, got %v", p.On.Push.Branches)
+	}
+	if len(p.On.Push.Tags) != 1 || p.On.Push.Tags[0] != "v*" {
+		t.Fatalf("expected tags [v*], got %v", p.On.Push.Tags)
+	}
+}
+
 func TestDuplicateJobNamePanics(t *testing.T) {
 	defer func() {
 		if r := recover(); r == nil {

--- a/pkg/pisyn/ir_test.go
+++ b/pkg/pisyn/ir_test.go
@@ -375,6 +375,23 @@ func TestIR_TriggersPreserved(t *testing.T) {
 	}
 }
 
+func TestIR_OnPushTagPreserved(t *testing.T) {
+	app := NewApp()
+	NewPipeline(app, "Release").
+		OnPushTag("v*")
+
+	ir := app.ToIR()
+	data, _ := json.Marshal(ir)
+	var loaded IRApp
+	json.Unmarshal(data, &loaded)
+	app2 := loaded.ToApp()
+
+	p := app2.Pipelines()[0]
+	if p.On.Push == nil || len(p.On.Push.Tags) != 1 || p.On.Push.Tags[0] != "v*" {
+		t.Error("push tags lost in IR roundtrip")
+	}
+}
+
 func TestLoadIR_FileNotFound(t *testing.T) {
 	_, err := LoadIR("/nonexistent/pipeline.json")
 	if err == nil {

--- a/pkg/pisyn/job.go
+++ b/pkg/pisyn/job.go
@@ -33,15 +33,17 @@ type Job struct {
 	DependencyList  []string
 	EmptyNeeds      bool
 	OutputList      []JobOutput
+	FetchDepth      int // 0 = full history, -1 = default (unset)
 }
 
 // NewJob creates a new job in the given stage.
 func NewJob(scope *Stage, name string) *Job {
 	checkDuplicateJobName(scope, name)
 	j := &Job{
-		JobName: name,
-		Runner:  "ubuntu-latest",
-		EnvVars: map[string]string{},
+		JobName:    name,
+		Runner:     "ubuntu-latest",
+		EnvVars:    map[string]string{},
+		FetchDepth: -1,
 	}
 	j.Construct = newConstruct(&scope.Construct, name, j)
 	return j
@@ -50,9 +52,10 @@ func NewJob(scope *Stage, name string) *Job {
 // JobTemplate creates a Job without a scope — for use as a reusable template.
 func JobTemplate(name string) *Job {
 	return &Job{
-		JobName: name,
-		Runner:  "ubuntu-latest",
-		EnvVars: map[string]string{},
+		JobName:    name,
+		Runner:     "ubuntu-latest",
+		EnvVars:    map[string]string{},
+		FetchDepth: -1,
 	}
 }
 
@@ -81,6 +84,7 @@ func (j *Job) Clone(scope *Stage, name string) *Job {
 		DependencyList:  cloneStrings(j.DependencyList),
 		EmptyNeeds:      j.EmptyNeeds,
 		OutputList:      cloneSlice(j.OutputList),
+		FetchDepth:      j.FetchDepth,
 	}
 	if j.ArtifactsCfg != nil {
 		a := *j.ArtifactsCfg
@@ -113,6 +117,9 @@ func (j *Job) ImageEntrypoint(cmds ...string) *Job { j.ImageEP = cmds; return j 
 
 // ImageUser sets the Docker user for the image.
 func (j *Job) ImageUser(user string) *Job { j.ImageUsr = user; return j }
+
+// SetFetchDepth sets the checkout fetch depth (0 = full history).
+func (j *Job) SetFetchDepth(depth int) *Job { j.FetchDepth = depth; return j }
 
 // Script appends a script block to the job's actions.
 func (j *Job) Script(cmds ...string) *Job {

--- a/pkg/pisyn/pipeline.go
+++ b/pkg/pisyn/pipeline.go
@@ -50,6 +50,15 @@ func (p *Pipeline) OnPushProtected() *Pipeline {
 	return p
 }
 
+// OnPushTag adds a push trigger for the given tag patterns (e.g. "v*").
+func (p *Pipeline) OnPushTag(patterns ...string) *Pipeline {
+	if p.On.Push == nil {
+		p.On.Push = &PushTrigger{}
+	}
+	p.On.Push.Tags = patterns
+	return p
+}
+
 // OnPR adds a pull/merge request trigger for the given target branches.
 func (p *Pipeline) OnPR(branches ...string) *Pipeline {
 	p.On.PullRequest = &PRTrigger{Branches: branches}

--- a/pkg/pisyn/types.go
+++ b/pkg/pisyn/types.go
@@ -122,6 +122,7 @@ type AllowFailureConfig struct {
 // PushTrigger configures a push event trigger.
 type PushTrigger struct {
 	Branches  []string `json:"branches,omitempty"`
+	Tags      []string `json:"tags,omitempty"`
 	Protected bool     `json:"protected,omitempty"`
 }
 

--- a/pkg/pisyn/vars.go
+++ b/pkg/pisyn/vars.go
@@ -13,6 +13,7 @@ const (
 	VarJobName        = "$PISYN_JOB_NAME"
 	VarJobToken       = "$PISYN_JOB_TOKEN"
 	VarProjectPath    = "$PISYN_PROJECT_PATH"
+	VarProjectURL     = "$PISYN_PROJECT_URL"
 	VarProjectDir     = "$PISYN_PROJECT_DIR"
 	VarProjectName    = "$PISYN_PROJECT_NAME"
 	VarProjectNS      = "$PISYN_PROJECT_NAMESPACE"
@@ -34,6 +35,7 @@ var GitLabVars = map[string]string{
 	"PISYN_JOB_NAME":          "CI_JOB_NAME",
 	"PISYN_JOB_TOKEN":         "CI_JOB_TOKEN",
 	"PISYN_PROJECT_PATH":      "CI_PROJECT_PATH",
+	"PISYN_PROJECT_URL":       "CI_REPOSITORY_URL",
 	"PISYN_PROJECT_DIR":       "CI_PROJECT_DIR",
 	"PISYN_PROJECT_NAME":      "CI_PROJECT_NAME",
 	"PISYN_PROJECT_NAMESPACE": "CI_PROJECT_NAMESPACE",
@@ -55,6 +57,7 @@ var GitHubVars = map[string]string{
 	"PISYN_JOB_NAME":          "${{ github.job }}",
 	"PISYN_JOB_TOKEN":         "${{ secrets.GITHUB_TOKEN }}",
 	"PISYN_PROJECT_PATH":      "${{ github.repository }}",
+	"PISYN_PROJECT_URL":       "${{ github.server_url }}/${{ github.repository }}",
 	"PISYN_PROJECT_DIR":       "${GITHUB_WORKSPACE}",
 	"PISYN_PROJECT_NAME":      "${{ github.event.repository.name }}",
 	"PISYN_PROJECT_NAMESPACE": "${{ github.repository_owner }}",
@@ -76,6 +79,7 @@ var TektonVars = map[string]string{
 	"PISYN_JOB_NAME":          "$(params.job-name)",
 	"PISYN_JOB_TOKEN":         "$(params.job-token)",
 	"PISYN_PROJECT_PATH":      "$(params.project-path)",
+	"PISYN_PROJECT_URL":       "$(params.project-url)",
 	"PISYN_PROJECT_DIR":       "$(workspaces.source.path)",
 	"PISYN_PROJECT_NAME":      "$(params.project-name)",
 	"PISYN_PROJECT_NAMESPACE": "$(params.project-namespace)",

--- a/pkg/synth/github/github.go
+++ b/pkg/synth/github/github.go
@@ -255,7 +255,20 @@ func buildSteps(job *pisyn.Job) []map[string]any {
 	var steps []map[string]any
 
 	// Every job starts with a checkout
-	steps = append(steps, map[string]any{"uses": "actions/checkout@v5"})
+	checkout := map[string]any{"uses": "actions/checkout@v5"}
+	if job.FetchDepth >= 0 {
+		checkout["with"] = map[string]any{"fetch-depth": fmt.Sprintf("%d", job.FetchDepth)}
+	}
+	steps = append(steps, checkout)
+
+	// Container jobs with full git history need safe.directory — the checkout
+	// action's config uses a temporary HOME that doesn't persist to subsequent steps.
+	if job.ImageName != "" && job.FetchDepth >= 0 {
+		steps = append(steps, map[string]any{
+			"name": "Mark workspace as safe directory",
+			"run":  "git config --global --add safe.directory ${GITHUB_WORKSPACE}",
+		})
+	}
 
 	// Dependency caching (rendered as an actions/cache step)
 	if job.CacheCfg != nil {

--- a/pkg/synth/github/github.go
+++ b/pkg/synth/github/github.go
@@ -68,7 +68,16 @@ func (syn *Synthesizer) renderPipeline(pipeline *pisyn.Pipeline) *synth.OrderedM
 func renderTriggers(triggers pisyn.Triggers) map[string]any {
 	on := map[string]any{}
 	if triggers.Push != nil {
-		on["push"] = map[string]any{"branches": triggers.Push.Branches}
+		push := map[string]any{}
+		if len(triggers.Push.Branches) > 0 {
+			push["branches"] = triggers.Push.Branches
+		}
+		if len(triggers.Push.Tags) > 0 {
+			push["tags"] = triggers.Push.Tags
+		}
+		if len(push) > 0 {
+			on["push"] = push
+		}
 	}
 	if triggers.PullRequest != nil {
 		on["pull_request"] = map[string]any{"branches": triggers.PullRequest.Branches}

--- a/pkg/synth/github/github_test.go
+++ b/pkg/synth/github/github_test.go
@@ -285,3 +285,34 @@ func TestSynthGitHubOutputs(t *testing.T) {
 		}
 	}
 }
+
+func TestSynthGitHubOnPushTag(t *testing.T) {
+	dir := t.TempDir()
+	app := pisyn.NewApp()
+	app.OutDir = dir
+
+	p := pisyn.NewPipeline(app, "Release").OnPushTag("v*")
+	s := pisyn.NewStage(p, "release")
+	pisyn.NewJob(s, "goreleaser").Image("golang:1.26").Script("echo release")
+
+	if err := app.Synth(github.NewSynthesizer()); err != nil {
+		t.Fatalf("synth: %v", err)
+	}
+
+	b, _ := os.ReadFile(filepath.Join(dir, ".github", "workflows", "release.yml"))
+	out := string(b)
+
+	for _, want := range []string{
+		"tags:",
+		"- v*",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in output:\n%s", want, out)
+		}
+	}
+
+	// Should not have branches key when only tags are set
+	if strings.Contains(out, "branches:") {
+		t.Errorf("unexpected 'branches:' in tag-only trigger:\n%s", out)
+	}
+}

--- a/pkg/synth/gitlab/gitlab.go
+++ b/pkg/synth/gitlab/gitlab.go
@@ -24,11 +24,72 @@ func (syn *Synthesizer) Synth(app *pisyn.App, outDir string) error {
 	pipelines := app.Pipelines()
 	if len(pipelines) == 1 {
 		out := syn.renderPipeline(pipelines[0])
-		return synth.WriteYAML(outDir, ".gitlab-ci.yml", out); err != nil {
-			return err
+		return synth.WriteYAML(outDir, ".gitlab-ci.yml", out)
+	}
+	return syn.renderMerged(pipelines, outDir)
+}
+
+// renderMerged merges multiple pipelines into a single .gitlab-ci.yml.
+// Each pipeline's triggers become job-level rules so jobs only run in the right context.
+func (syn *Synthesizer) renderMerged(pipelines []*pisyn.Pipeline, outDir string) error {
+	cfg := synth.NewOrderedMap()
+
+	// Collect all stages, includes, env, and workflow rules across pipelines
+	var allStages []string
+	var allWorkflowRules []map[string]any
+	var allIncludes []pisyn.Include
+	allEnv := map[string]string{}
+	seen := map[string]bool{}
+
+	for _, pipeline := range pipelines {
+		for _, stage := range pipeline.Stages() {
+			if !seen[stage.Name] {
+				allStages = append(allStages, stage.Name)
+				seen[stage.Name] = true
+			}
+		}
+		if len(pipeline.WorkflowRules) > 0 {
+			allWorkflowRules = append(allWorkflowRules, renderRuleList(pipeline.WorkflowRules)...)
+		} else if wfRules := renderWorkflowRules(pipeline.On); len(wfRules) > 0 {
+			allWorkflowRules = append(allWorkflowRules, wfRules...)
+		}
+		for key, val := range pipeline.Env {
+			allEnv[key] = translateVars(val)
+		}
+		allIncludes = append(allIncludes, pipeline.IncludeList...)
+	}
+
+	if len(allIncludes) > 0 {
+		cfg.Set("include", renderIncludes(allIncludes))
+	}
+	if len(allStages) > 0 {
+		cfg.Set("stages", allStages)
+	}
+	if len(allWorkflowRules) > 0 {
+		cfg.Set("workflow", map[string]any{"rules": allWorkflowRules})
+	}
+	if len(allEnv) > 0 {
+		cfg.Set("variables", allEnv)
+	}
+
+	// Render jobs, injecting pipeline-level trigger rules onto jobs that don't have their own
+	for _, pipeline := range pipelines {
+		pipelineRules := renderWorkflowRules(pipeline.On)
+		if len(pipeline.WorkflowRules) > 0 {
+			pipelineRules = renderRuleList(pipeline.WorkflowRules)
+		}
+		for _, stage := range pipeline.Stages() {
+			for _, job := range stage.Jobs() {
+				rendered := renderJob(job, stage.Name)
+				if len(job.Rules) == 0 && len(pipelineRules) > 0 {
+					rendered["rules"] = pipelineRules
+				}
+				cfg.Set(job.JobName, rendered)
+			}
 		}
 	}
-	return nil
+
+	return synth.WriteYAML(outDir, ".gitlab-ci.yml", cfg)
 }
 
 func (syn *Synthesizer) renderPipeline(pipeline *pisyn.Pipeline) *synth.OrderedMap {

--- a/pkg/synth/gitlab/gitlab.go
+++ b/pkg/synth/gitlab/gitlab.go
@@ -21,9 +21,10 @@ func init() {
 
 // Synth generates GitLab CI YAML from the app's construct tree.
 func (syn *Synthesizer) Synth(app *pisyn.App, outDir string) error {
-	for _, pipeline := range app.Pipelines() {
-		out := syn.renderPipeline(pipeline)
-		if err := synth.WriteYAML(outDir, ".gitlab-ci.yml", out); err != nil {
+	pipelines := app.Pipelines()
+	if len(pipelines) == 1 {
+		out := syn.renderPipeline(pipelines[0])
+		return synth.WriteYAML(outDir, ".gitlab-ci.yml", out); err != nil {
 			return err
 		}
 	}
@@ -131,6 +132,12 @@ func renderWorkflowRules(triggers pisyn.Triggers) []map[string]any {
 				"when": "always",
 			})
 		}
+		for _, tag := range triggers.Push.Tags {
+			rules = append(rules, map[string]any{
+				"if":   fmt.Sprintf(`$CI_COMMIT_TAG =~ /^%s/`, tagPatternToRegex(tag)),
+				"when": "always",
+			})
+		}
 	}
 	if triggers.PullRequest != nil {
 		rules = append(rules, map[string]any{
@@ -145,6 +152,11 @@ func renderWorkflowRules(triggers pisyn.Triggers) []map[string]any {
 		})
 	}
 	return rules
+}
+
+// tagPatternToRegex converts a glob-style tag pattern (e.g. "v*") to a regex fragment.
+func tagPatternToRegex(pattern string) string {
+	return strings.ReplaceAll(pattern, "*", ".*")
 }
 
 // renderIncludes converts pisyn Include entries to GitLab CI include format.

--- a/pkg/synth/gitlab/gitlab_test.go
+++ b/pkg/synth/gitlab/gitlab_test.go
@@ -199,3 +199,24 @@ func TestSynthGitLabOutputs(t *testing.T) {
 		t.Errorf("untranslated PISYN_OUTPUT in output:\n%s", out)
 	}
 }
+
+func TestSynthGitLabOnPushTag(t *testing.T) {
+	dir := t.TempDir()
+	app := pisyn.NewApp()
+	app.OutDir = dir
+
+	p := pisyn.NewPipeline(app, "Release").OnPushTag("v*")
+	s := pisyn.NewStage(p, "release")
+	pisyn.NewJob(s, "goreleaser").Image("golang:1.26").Script("echo release")
+
+	if err := app.Synth(gitlab.NewSynthesizer()); err != nil {
+		t.Fatalf("synth: %v", err)
+	}
+
+	b, _ := os.ReadFile(filepath.Join(dir, ".gitlab-ci.yml"))
+	out := string(b)
+
+	if !strings.Contains(out, `$CI_COMMIT_TAG =~ /^v.*/`) {
+		t.Errorf("missing tag workflow rule in output:\n%s", out)
+	}
+}


### PR DESCRIPTION
New API: OnPushTag()
- Added Tags []string to PushTrigger struct
- pipeline.OnPushTag("v*") renders as on: push: tags: [v*] (GitHub) and $CI_COMMIT_TAG =~ /^v.*/ (GitLab)

New API: SetFetchDepth()
- Added FetchDepth field to Job (default -1 = unset)
- job.SetFetchDepth(0) renders fetch-depth: "0" on the auto-generated checkout step
- Properly propagated through Clone()

Container safe.directory fix
- GitHub synth auto-injects git config --global --add safe.directory ${GITHUB_WORKSPACE} after checkout for container jobs that set FetchDepth (i.e., jobs that need git history and therefore have
git installed)

New variable: VarProjectURL
- Maps to $CI_REPOSITORY_URL (GitLab), ${{ github.server_url }}/${{ github.repository }} (GitHub)

GitLab multi-pipeline merge
- GitLab synth now merges multiple pipelines into a single .gitlab-ci.yml with combined workflow rules and per-job trigger rules

Pipeline restructure
- Split into buildPipeline, releasePleasePipeline, releasePipeline
- Added .goreleaser.yml and release workflows