### PR TITLE
fix: deep-copy pointer fields in Job.Clone()

### DIFF
--- a/pkg/pisyn/job.go
+++ b/pkg/pisyn/job.go
@@ -109,6 +109,18 @@ func (j *Job) Clone(scope *Stage, name string) *Job {
 		e := *j.EnvironmentCfg
 		c.EnvironmentCfg = &e
 	}
+	if j.RetryCfg != nil {
+		r := *j.RetryCfg
+		c.RetryCfg = &r
+	}
+	if j.AllowFailureCfg != nil {
+		af := *j.AllowFailureCfg
+		c.AllowFailureCfg = &af
+	}
+	if j.Interruptible != nil {
+		v := *j.Interruptible
+		c.Interruptible = &v
+	}
 	c.Construct = newConstruct(&scope.Construct, name, c)
 	return c
 }


### PR DESCRIPTION
Fixes #7

`Clone()` shallow-copied `RetryCfg`, `AllowFailureCfg`, and `Interruptible` pointer fields, so mutations to a cloned job corrupted the original template. Added deep-copy following the existing pattern for `ArtifactsCfg`/`CacheCfg`/`EnvironmentCfg`.