### PR TITLE
docs(build): add Makefile with update-schemas target

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,16 @@ go test ./pkg/synth/gitlab/     # gitlab synthesizer only
 go test -cover ./...             # with coverage
 ```
 
+## Updating bundled schemas
+
+`pkg/validate/schemas/` holds the JSON schemas bundled into the binary via `//go:embed`. When upstream schemas change, refresh the local copies:
+
+```sh
+make update-schemas
+```
+
+That target downloads the latest `gitlab-ci.json` and `github-workflow.json` from their canonical sources (GitLab `gitlab-org/gitlab` and [json.schemastore.org](https://json.schemastore.org/)) into `pkg/validate/schemas/`. Review the diff with `git diff pkg/validate/schemas/` and commit the updated files.
+
 ## Commit Messages
 
 We use [Conventional Commits](https://www.conventionalcommits.org/) for automated releases:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+# Variables
+SCHEMAS_DIR   := pkg/validate/schemas
+GITLAB_URL    := https://gitlab.com/gitlab-org/gitlab/-/raw/master/app/assets/javascripts/editor/schema/ci.json
+GITHUB_URL    := https://json.schemastore.org/github-workflow.json
+
+.PHONY: help build test update-schemas
+
+help:
+	@echo "Available targets:"
+	@echo "  build            Build the pisyn binary"
+	@echo "  test             Run unit tests"
+	@echo "  update-schemas   Refresh bundled CI schemas from upstream (GitLab + GitHub)"
+
+build:
+	go build ./...
+
+test:
+	go test ./...
+
+update-schemas:
+	@echo "Fetching GitLab CI schema from $(GITLAB_URL)"
+	curl -fsSL $(GITLAB_URL) -o $(SCHEMAS_DIR)/gitlab-ci.json
+	@echo "Fetching GitHub Actions workflow schema from $(GITHUB_URL)"
+	curl -fsSL $(GITHUB_URL) -o $(SCHEMAS_DIR)/github-workflow.json
+	@echo "Schemas updated. Review with: git diff $(SCHEMAS_DIR)"


### PR DESCRIPTION
## Summary

Closes #12. Adds a `Makefile` with an `update-schemas` target that refreshes the bundled JSON schemas in `pkg/validate/schemas/` from their upstream sources, plus a matching section in `CONTRIBUTING.md` explaining when and how to run it.

## Why this matters

`pkg/validate/schemas/gitlab-ci.json` and `pkg/validate/schemas/github-workflow.json` are embedded via `//go:embed` (see `pkg/validate/validate.go:13`). When GitLab's `gitlab-org/gitlab` or `json.schemastore.org` ship schema updates, the bundled copies go stale — and there was no documented process for refreshing them. This PR closes that gap with a one-command workflow.

The README already links both upstream sources (lines 175-177), so no new URLs are invented here.

## Changes

**`Makefile`** (new, 25 lines):

```make
SCHEMAS_DIR   := pkg/validate/schemas
GITLAB_URL    := https://gitlab.com/gitlab-org/gitlab/-/raw/master/app/assets/javascripts/editor/schema/ci.json
GITHUB_URL    := https://json.schemastore.org/github-workflow.json

.PHONY: help build test update-schemas

help:
	@echo "Available targets: ..."

build:
	go build ./...

test:
	go test ./...

update-schemas:
	curl -fsSL $(GITLAB_URL) -o $(SCHEMAS_DIR)/gitlab-ci.json
	curl -fsSL $(GITHUB_URL) -o $(SCHEMAS_DIR)/github-workflow.json
```

I also included `build` and `test` targets since they're the existing commands mentioned in CONTRIBUTING.md under Quick Setup — having a single canonical Makefile keeps things discoverable.

**`CONTRIBUTING.md`** — added a short `## Updating bundled schemas` section between `## Running Tests` and `## Commit Messages` describing the target, where the schemas live, and the expected review step (`git diff pkg/validate/schemas/`).

## Testing

- `make help` — lists the three targets.
- `make update-schemas` — successfully fetches both upstream schemas (curl exits 0, files update on disk). For this PR I reverted the refreshed schema files since they aren't the point of the change; a follow-up can commit the updated schemas if/when wanted.
- `make build` — `go build ./...` succeeds, identical behaviour to running the command directly.
- `make test` — all existing test suites pass.

## Scope note

Chose a Makefile target over a `//go:generate` directive because (a) Go projects with downloadable external resources typically use Makefiles for this (both paths are suggested in the issue), (b) it surfaces the command via `make help`, and (c) `go:generate` requires running `go generate` explicitly, which is less discoverable than `make update-schemas`.

Closes #12

This contribution was developed with AI assistance (Claude Code).
