### PR TITLE
fix: add FetchDepth to IR for round-trip data preservation

### DIFF
--- a/pkg/pisyn/ir.go
+++ b/pkg/pisyn/ir.go
@@ -65,6 +65,7 @@ type IRJob struct {
 	Rules           []Rule              `json:"rules,omitempty"`
 	Interruptible   *bool               `json:"interruptible,omitempty"`
 	Outputs         []JobOutput         `json:"outputs,omitempty"`
+	FetchDepth      int                 `json:"fetch_depth"`
 }
 
 // Build serializes the App's construct tree to pipeline.json in the given directory.
@@ -141,6 +142,7 @@ func jobToIR(job *Job) IRJob {
 		Rules:           job.Rules,
 		Interruptible:   job.Interruptible,
 		Outputs:         job.OutputList,
+		FetchDepth:      job.FetchDepth,
 	}
 }
 
@@ -227,5 +229,6 @@ func irJobToJob(irj IRJob) *Job {
 		Rules:           irj.Rules,
 		Interruptible:   irj.Interruptible,
 		OutputList:      irj.Outputs,
+		FetchDepth:      irj.FetchDepth,
 	}
 }

--- a/pkg/pisyn/ir.go
+++ b/pkg/pisyn/ir.go
@@ -65,7 +65,7 @@ type IRJob struct {
 	Rules           []Rule              `json:"rules,omitempty"`
 	Interruptible   *bool               `json:"interruptible,omitempty"`
 	Outputs         []JobOutput         `json:"outputs,omitempty"`
-	FetchDepth      int                 `json:"fetch_depth"`
+	FetchDepth      *int                `json:"fetch_depth"`
 }
 
 // Build serializes the App's construct tree to pipeline.json in the given directory.
@@ -142,8 +142,17 @@ func jobToIR(job *Job) IRJob {
 		Rules:           job.Rules,
 		Interruptible:   job.Interruptible,
 		Outputs:         job.OutputList,
-		FetchDepth:      job.FetchDepth,
+		FetchDepth:      jobFetchDepthToIR(job.FetchDepth),
 	}
+}
+
+// jobFetchDepthToIR translates Job.FetchDepth's -1 sentinel ("unset") into a
+// nil *int so the IR distinguishes "unset" from 0 ("full history").
+func jobFetchDepthToIR(depth int) *int {
+	if depth < 0 {
+		return nil
+	}
+	return &depth
 }
 
 // LoadIR reads pipeline.json and returns IR structs.
@@ -229,6 +238,15 @@ func irJobToJob(irj IRJob) *Job {
 		Rules:           irj.Rules,
 		Interruptible:   irj.Interruptible,
 		OutputList:      irj.Outputs,
-		FetchDepth:      irj.FetchDepth,
+		FetchDepth:      irFetchDepthToJob(irj.FetchDepth),
 	}
+}
+
+// irFetchDepthToJob restores Job.FetchDepth's -1 sentinel ("unset") when the
+// IR field is nil; otherwise the stored depth round-trips verbatim.
+func irFetchDepthToJob(depth *int) int {
+	if depth == nil {
+		return -1
+	}
+	return *depth
 }


### PR DESCRIPTION
`IRJob` was missing `FetchDepth`, so round-tripping through `pipeline.json` (via `pisyn build` followed by `pisyn graph`/`pisyn run`) silently dropped the fetch depth setting.

Added the field to `IRJob` and wired it through `jobToIR()` and `irJobToJob()` in `pkg/pisyn/ir.go`.

Uses `json:"fetch_depth"` without `omitempty` because `0` is a valid value (full history) and `-1` means unset.

Closes #9