### PR TITLE
feat(graph): group jobs by stage using Mermaid subgraph

### DIFF
--- a/pkg/pisyn/app.go
+++ b/pkg/pisyn/app.go
@@ -98,28 +98,32 @@ func (a *App) Run() error {
 // Graph returns a Mermaid flowchart of the pipeline's job dependency graph.
 func (a *App) Graph() string {
 	var b strings.Builder
+	var edges strings.Builder
 	b.WriteString("graph LR\n")
 	for _, pipeline := range a.Pipelines() {
 		var prevStageJobs []string
 		for _, stage := range pipeline.Stages() {
 			var currentJobs []string
+			fmt.Fprintf(&b, "    subgraph %s[%q]\n", sanitizeID(stage.Name), stage.Name)
 			for _, job := range stage.Jobs() {
 				id := sanitizeID(job.JobName)
-				fmt.Fprintf(&b, "    %s[%q]\n", id, job.JobName)
+				fmt.Fprintf(&b, "        %s[%q]\n", id, job.JobName)
 				if len(job.NeedsList) > 0 {
 					for _, need := range job.NeedsList {
-						fmt.Fprintf(&b, "    %s --> %s\n", sanitizeID(need), id)
+						fmt.Fprintf(&edges, "    %s --> %s\n", sanitizeID(need), id)
 					}
 				} else if len(prevStageJobs) > 0 {
 					for _, prev := range prevStageJobs {
-						fmt.Fprintf(&b, "    %s --> %s\n", prev, id)
+						fmt.Fprintf(&edges, "    %s --> %s\n", prev, id)
 					}
 				}
 				currentJobs = append(currentJobs, id)
 			}
+			b.WriteString("    end\n")
 			prevStageJobs = currentJobs
 		}
 	}
+	b.WriteString(edges.String())
 	return b.String()
 }
 

--- a/pkg/pisyn/coverage_test.go
+++ b/pkg/pisyn/coverage_test.go
@@ -5,20 +5,22 @@ import "testing"
 func TestGraph(t *testing.T) {
 	app := NewApp()
 	p := NewPipeline(app, "CI")
-	s1 := NewStage(p, "build")
-	NewJob(s1, "compile").Image("alpine")
-	s2 := NewStage(p, "test")
-	NewJob(s2, "unit").Image("alpine").Needs("compile")
+	s1 := NewStage(p, "build-steps")
+	NewJob(s1, "compile-go").Image("alpine")
+	s2 := NewStage(p, "test stage.one")
+	NewJob(s2, "unit.tests").Image("alpine")
 
 	g := app.Graph()
-	if g == "" {
-		t.Fatal("graph is empty")
-	}
-	if !contains(g, "compile") || !contains(g, "unit") {
-		t.Errorf("graph missing jobs: %s", g)
-	}
-	if !contains(g, "-->") {
-		t.Error("graph missing edges")
+	want := "graph LR\n" +
+		"    subgraph build_steps[\"build-steps\"]\n" +
+		"        compile_go[\"compile-go\"]\n" +
+		"    end\n" +
+		"    subgraph test_stage_one[\"test stage.one\"]\n" +
+		"        unit_tests[\"unit.tests\"]\n" +
+		"    end\n" +
+		"    compile_go --> unit_tests\n"
+	if g != want {
+		t.Errorf("Graph() = %q, want %q", g, want)
 	}
 }
 


### PR DESCRIPTION
## Summary
Group job nodes by stage in the Mermaid graph output, wrapping each stage in a `subgraph` block. Dependency edges emit after the subgraphs so Mermaid renders cross-stage arrows correctly.

## Why this matters
Issue #10 points at `pkg/pisyn/app.go` `Graph()` (line 99): the current output lists every job at the top level, so a reader has to reconstruct stage membership from the dependency edges. Pipelines already declare stages via `NewStage(p, name)` (see `pkg/pisyn/stage.go`), and that structure is lost in the rendered graph.

The issue's expected output shows `subgraph lint ... end` and `subgraph test ... end` blocks with cross-stage edges emitted after. This PR matches that format.

## Changes
- `pkg/pisyn/app.go`: `Graph()` opens `subgraph <sanitized>["<Name>"]` per stage, emits job nodes indented inside, then `end`. Dependency edges are buffered in a second `strings.Builder` and appended after all subgraphs close so they sit at the top level of the Mermaid graph.
- `pkg/pisyn/coverage_test.go`: `TestGraph` now asserts the exact Mermaid string with two stages and a cross-stage edge, and uses stage names with hyphens/spaces/dots to exercise `sanitizeID`.

## Testing
- `go build ./...` - pass
- `go test ./...` - pass (all existing tests, plus updated `TestGraph`)

Fixes #10

This contribution was developed with AI assistance (Codex).
