### PR TITLE
fix(pisyn): deep-copy RetryCfg, AllowFailureCfg, Interruptible in Job.Clone

### DIFF
--- a/pkg/pisyn/job.go
+++ b/pkg/pisyn/job.go
@@ -77,14 +77,11 @@ func (j *Job) Clone(scope *Stage, name string) *Job {
 		ServiceList:     cloneSlice(j.ServiceList),
 		EnvVars:         cloneMap(j.EnvVars),
 		IsAllowFailure:  j.IsAllowFailure,
-		AllowFailureCfg: j.AllowFailureCfg,
 		TimeoutMin:      j.TimeoutMin,
 		RetryCount:      j.RetryCount,
-		RetryCfg:        j.RetryCfg,
 		When:            j.When,
 		Tags:            cloneStrings(j.Tags),
 		Rules:           cloneSlice(j.Rules),
-		Interruptible:   j.Interruptible,
 		DependencyList:  cloneStrings(j.DependencyList),
 		EmptyNeeds:      j.EmptyNeeds,
 		OutputList:      cloneSlice(j.OutputList),
@@ -108,6 +105,24 @@ func (j *Job) Clone(scope *Stage, name string) *Job {
 	if j.EnvironmentCfg != nil {
 		e := *j.EnvironmentCfg
 		c.EnvironmentCfg = &e
+	}
+	// Deep-copy fields that were previously aliased by pointer so a clone
+	// can't mutate the template via RetryCfg.When, AllowFailureCfg.ExitCodes,
+	// or *Interruptible (#7).
+	if j.RetryCfg != nil {
+		r := *j.RetryCfg
+		r.When = cloneStrings(r.When)
+		r.ExitCodes = cloneSlice(r.ExitCodes)
+		c.RetryCfg = &r
+	}
+	if j.AllowFailureCfg != nil {
+		a := *j.AllowFailureCfg
+		a.ExitCodes = cloneSlice(a.ExitCodes)
+		c.AllowFailureCfg = &a
+	}
+	if j.Interruptible != nil {
+		v := *j.Interruptible
+		c.Interruptible = &v
 	}
 	c.Construct = newConstruct(&scope.Construct, name, c)
 	return c


### PR DESCRIPTION
Closes #7.

`Job.Clone` aliased `RetryCfg`, `AllowFailureCfg`, and `Interruptible` by pointer, so a clone mutating `RetryCfg.When` / `AllowFailureCfg.ExitCodes` / `*Interruptible` would scribble straight back into the template. `ArtifactsCfg` / `CacheCfg` / `MatrixCfg` / `EnvironmentCfg` were already properly deep-copied, so this PR just applies the same pattern to the three remaining fields:

- For `*RetryConfig`, allocate a fresh struct, `cloneStrings(r.When)`, and `cloneSlice(r.ExitCodes)`.
- For `*AllowFailureConfig`, allocate a fresh struct and `cloneSlice(a.ExitCodes)`.
- For `*bool` `Interruptible`, copy the bool into a new cell.

No behaviour change when all three fields are nil. Tests pass locally.