### PR TITLE
fix(ci): exclude unfixable docker vulns from govulncheck

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,10 +35,12 @@ jobs:
               with:
                 key: go-mod
                 path: /go/pkg/mod
+            - name: Install jq
+              run: apt-get update && apt-get install -y jq
             - name: Run
               run: |-
                 go install golang.org/x/vuln/cmd/govulncheck@latest
-                govulncheck ./...
+                ./scripts/govulncheck.sh
         runs-on: ubuntu-latest
         if: ${{ github.event.pull_request.number }}
     unit-tests:

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 ## macOS
 .DS_Store
 *.sh
+!scripts/*.sh
 
 ## Editor/IDE - vscode
 .vscode

--- a/scripts/govulncheck.sh
+++ b/scripts/govulncheck.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Wrapper for govulncheck that allows excluding specific vulnerabilities.
+# Each excluded vulnerability MUST link to a tracking issue with rationale.
+# See https://github.com/golang/go/issues/59507 for upstream support tracking.
+set -Eeuo pipefail
+
+# Vulnerabilities excluded until upstream ships a fix.
+# Each entry must link to a tracking issue and explain why suppression is safe.
+excludeVulns="$(jq -nc '[
+  # docker vulnerabilities (no fix available upstream).
+  # Issue: https://github.com/pipecrew/pisyn/issues/26
+  # Both affect Docker daemon AuthZ plugin paths, not the client SDK we use.
+  "GO-2026-4887", # CVE: Docker AuthZ plugin bypass
+  "GO-2026-4883", # CVE: Docker plugin privilege off-by-one
+
+  empty
+]')"
+export excludeVulns
+
+# Fast path: if govulncheck passes outright, no filtering needed.
+if govulncheck ./...; then
+  exit 0
+fi
+
+# Re-run in JSON mode so we can filter by ID.
+json="$(govulncheck -json ./...)"
+
+# Pull every vuln that has at least one called function in the trace.
+# (Vulns without a called function are informational and never fail govulncheck.)
+vulns="$(jq <<<"$json" -cs '
+  (map(.osv // empty | {key: .id, value: .}) | from_entries) as $meta
+  | map(.finding // empty | select((.trace[0].function // "") != "") | .osv)
+  | unique
+  | map($meta[.])
+')"
+
+# Drop excluded IDs.
+filtered="$(jq <<<"$vulns" -c '
+  (env.excludeVulns | fromjson) as $exclude
+  | map(select(.id as $id | $exclude | index($id) | not))
+')"
+
+text="$(jq <<<"$filtered" -r 'map("- \(.id) (aka \(.aliases | join(", ")))\n\n\t\(.details | gsub("\n"; "\n\t"))") | join("\n\n")')"
+
+if [ -z "$text" ]; then
+  echo "govulncheck passed (all findings are in the known-excluded list)"
+  exit 0
+else
+  printf '%s\n' "$text"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Closes #26. Wraps `govulncheck` in `scripts/govulncheck.sh` so we can suppress the two unfixable docker findings (GO-2026-4887, GO-2026-4883) without disabling vulncheck entirely. Both vulnerabilities live in the Docker daemon AuthZ plugin path, not the client SDK pisyn pulls in via testcontainers — issue #26 walks through why suppression is safe.

## Why this matters

Both findings have `Fixed in: N/A` upstream. Without a wrapper, the build either reports them forever (current behavior, with `continue-on-error: true` masking them) or fails permanently if you flip the gate on. The wrapper lets the build keep failing on real findings while explicitly tracking the two we've vetted.

The pattern is the one t0st linked from `bmarinov/garage-storage-controller#73`: run `govulncheck` first; if it passes, exit. Otherwise re-run with `-json` and filter the explicit allowlist of IDs. Findings without a called function are already informational so they don't fail govulncheck on their own — the script only filters what would otherwise be a fail.

## Changes

- **NEW** `scripts/govulncheck.sh` (executable): wrapper script with `excludeVulns` JSON array. Each excluded ID has an inline comment linking its tracking issue and naming the CVE so the exclusion stays auditable.
- `.github/workflows/build.yml`: vulncheck job installs `jq` (Debian-based golang container doesn't bundle it) and calls `./scripts/govulncheck.sh` instead of `govulncheck ./...`.
- `.gitignore`: added `!scripts/*.sh` to the top-level `*.sh` ignore so future helper scripts here are tracked while top-level shell scripts stay ignored.

## Testing

- `bash -n scripts/govulncheck.sh` — clean syntax.
- The wrapper's behavior matches the linked example PR; the only changes from that template are the comment text (links to pisyn's #26 instead of the original issue) and the formatting of the IDs.

When upstream ships a fix for either ID, just delete that line from `excludeVulns` in the script.

This contribution was developed with AI assistance (Claude Code).
