### PR TITLE
fix(runner/docker): record symlinks in tar instead of zero-content regular files

### DIFF
--- a/pkg/runner/docker.go
+++ b/pkg/runner/docker.go
@@ -218,7 +218,9 @@ func (d *DockerRunner) RunJob(ctx context.Context, job *pisyn.Job, extraEnv map[
 		return fmt.Errorf("create container: %w", err)
 	}
 	containerID := resp.ID
-	defer func() { _ = d.cli.ContainerRemove(context.Background(), containerID, container.RemoveOptions{Force: true}) }() // best-effort cleanup
+	defer func() {
+		_ = d.cli.ContainerRemove(context.Background(), containerID, container.RemoveOptions{Force: true})
+	}() // best-effort cleanup
 
 	// Start container
 	if err := d.cli.ContainerStart(ctx, containerID, container.StartOptions{}); err != nil {
@@ -315,7 +317,7 @@ func (d *DockerRunner) startServices(ctx context.Context, job *pisyn.Job, events
 
 func (d *DockerRunner) stopContainers(ctx context.Context, ids []string) {
 	for _, id := range ids {
-		_ = d.cli.ContainerStop(ctx, id, container.StopOptions{})       // best-effort cleanup
+		_ = d.cli.ContainerStop(ctx, id, container.StopOptions{})                // best-effort cleanup
 		_ = d.cli.ContainerRemove(ctx, id, container.RemoveOptions{Force: true}) // best-effort cleanup
 	}
 }
@@ -481,7 +483,19 @@ func tarDir(dir string) (io.Reader, error) {
 			return nil
 		}
 
-		header, err := tar.FileInfoHeader(info, "")
+		// filepath.Walk does not follow symlinks; info.Mode() carries
+		// the link bit and Lstat-style sizing. Read the link target so
+		// tar.FileInfoHeader records it as a Typeflag=Symlink entry
+		// instead of a zero-content regular file.
+		linkTarget := ""
+		if info.Mode()&os.ModeSymlink != 0 {
+			linkTarget, err = os.Readlink(path)
+			if err != nil {
+				return fmt.Errorf("readlink %s: %w", rel, err)
+			}
+		}
+
+		header, err := tar.FileInfoHeader(info, linkTarget)
 		if err != nil {
 			return err
 		}
@@ -490,7 +504,8 @@ func tarDir(dir string) (io.Reader, error) {
 		if err := tw.WriteHeader(header); err != nil {
 			return err
 		}
-		if info.IsDir() {
+		// Directories and symlinks have no body to copy.
+		if info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
 			return nil
 		}
 

--- a/pkg/runner/docker_test.go
+++ b/pkg/runner/docker_test.go
@@ -1,0 +1,109 @@
+package runner
+
+import (
+	"archive/tar"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestTarDirSymlink verifies that tarDir records symlinks as
+// Typeflag=Symlink with the correct link target instead of writing
+// a zero-content regular file (the bug reported in issue #8).
+func TestTarDirSymlink(t *testing.T) {
+	dir := t.TempDir()
+
+	target := filepath.Join(dir, "real.txt")
+	if err := os.WriteFile(target, []byte("hello"), 0o644); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	link := filepath.Join(dir, "link")
+	if err := os.Symlink("real.txt", link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	r, err := tarDir(dir)
+	if err != nil {
+		t.Fatalf("tarDir: %v", err)
+	}
+
+	var sawSymlink, sawRegular bool
+	tr := tar.NewReader(r)
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("tar read: %v", err)
+		}
+		switch hdr.Name {
+		case "link":
+			if hdr.Typeflag != tar.TypeSymlink {
+				t.Errorf("link: typeflag=%v want %v", hdr.Typeflag, tar.TypeSymlink)
+			}
+			if hdr.Linkname != "real.txt" {
+				t.Errorf("link: linkname=%q want %q", hdr.Linkname, "real.txt")
+			}
+			if hdr.Size != 0 {
+				t.Errorf("link: size=%d want 0", hdr.Size)
+			}
+			sawSymlink = true
+		case "real.txt":
+			if hdr.Typeflag != tar.TypeReg {
+				t.Errorf("real.txt: typeflag=%v want %v", hdr.Typeflag, tar.TypeReg)
+			}
+			sawRegular = true
+		}
+	}
+	if !sawSymlink {
+		t.Error("symlink entry missing from tar")
+	}
+	if !sawRegular {
+		t.Error("regular-file entry missing from tar")
+	}
+}
+
+// TestTarDirBrokenSymlink verifies that tarDir surfaces a clear error
+// rather than producing a zero-content regular file when a symlink
+// target cannot be resolved.
+func TestTarDirBrokenSymlink(t *testing.T) {
+	dir := t.TempDir()
+
+	// Symlink whose target does not exist.
+	link := filepath.Join(dir, "broken")
+	if err := os.Symlink("does-not-exist", link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	r, err := tarDir(dir)
+	if err != nil {
+		t.Fatalf("tarDir on broken symlink: unexpected error %v", err)
+	}
+
+	var sawSymlink bool
+	tr := tar.NewReader(r)
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("tar read: %v", err)
+		}
+		if hdr.Name == "broken" {
+			sawSymlink = true
+			if hdr.Typeflag != tar.TypeSymlink {
+				t.Errorf("broken: typeflag=%v want %v", hdr.Typeflag, tar.TypeSymlink)
+			}
+			if hdr.Linkname != "does-not-exist" {
+				t.Errorf("broken: linkname=%q want %q", hdr.Linkname, "does-not-exist")
+			}
+		}
+	}
+	if !sawSymlink {
+		t.Error("broken symlink entry missing from tar")
+	}
+}


### PR DESCRIPTION
Closes part of #8 (the third bullet — symlink handling). Leaves the `.git/` and `.dockerignore`/`.gitignore` filtering work for a follow-up PR.

`tarDir()` in `pkg/runner/docker.go` walked the workspace with `filepath.Walk` and called `tar.FileInfoHeader(info, "")` on every entry. For a symlink that recorded a regular-file header sized to the link itself with no body, so the receiving side saw a zero-content stub instead of the link.

This PR:

- Detects the symlink bit on `info.Mode()` and passes `os.Readlink(path)` as the link target to `tar.FileInfoHeader`. The resulting header has `Typeflag=Symlink` and the correct `Linkname`.
- Skips the `io.Copy` step for symlinks (no body to write).
- Preserves broken symlinks (target does not exist) by recording the dangling target in the tar header instead of silently emitting a zero-content regular file.

## Tests

Adds two tests in `pkg/runner/docker_test.go`:

- `TestTarDirSymlink`: writes a real file plus a symlink to it, tars the dir, walks the tar and asserts the link is `tar.TypeSymlink` with `Linkname == "real.txt"` and `Size == 0`, and the regular file is still `tar.TypeReg`.
- `TestTarDirBrokenSymlink`: creates a symlink to a non-existent target and asserts the tar still records `tar.TypeSymlink` with the dangling `Linkname` preserved.

Both pass locally. `go test ./pkg/runner/...` is green; `go vet ./...` is clean.